### PR TITLE
adc state machine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,16 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
 dependencies = [
- "enum-iterator-derive",
+ "enum-iterator-derive 0.6.0",
+]
+
+[[package]]
+name = "enum-iterator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
+dependencies = [
+ "enum-iterator-derive 0.7.0",
 ]
 
 [[package]]
@@ -304,6 +313,17 @@ name = "enum-iterator-derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -448,7 +468,7 @@ dependencies = [
  "minimq",
  "serde",
  "serde-json-core",
- "smlang",
+ "smlang 0.4.2",
 ]
 
 [[package]]
@@ -460,9 +480,9 @@ dependencies = [
  "bit_field",
  "embedded-nal",
  "embedded-time",
- "enum-iterator",
+ "enum-iterator 0.6.0",
  "heapless",
- "smlang",
+ "smlang 0.4.2",
 ]
 
 [[package]]
@@ -790,7 +810,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f6a641648330c38cc8e0574ddc03807617dc8f27f3005c368522769f818896"
 dependencies = [
- "smlang-macros",
+ "smlang-macros 0.2.1",
+]
+
+[[package]]
+name = "smlang"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8a20583c0a718b7ab6ea17871a1bb0c55911df67277d255418e9e82167f44e"
+dependencies = [
+ "smlang-macros 0.5.1",
 ]
 
 [[package]]
@@ -798,6 +827,17 @@ name = "smlang-macros"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6db7d915f8478423db4889a8933f0f557ec345b3e94495800d7b32b1ac7250"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "smlang-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20fec38ee915442c56be307cc054a490131b335212054b7cdc3bf0f73da4d8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -908,6 +948,7 @@ dependencies = [
  "defmt",
  "defmt-rtt",
  "embedded-time",
+ "enum-iterator 0.7.0",
  "heapless",
  "log",
  "miniconf",
@@ -918,6 +959,7 @@ dependencies = [
  "serde",
  "serde-json-core",
  "shared-bus-rtic",
+ "smlang 0.5.1",
  "smoltcp-nal",
  "stm32h7xx-hal",
  "systick-monotonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ defmt-rtt = "0.3.0"
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 shared-bus-rtic = { version = "0.2", features = ["cortex-m"] }
 byteorder = { version = "1", default-features = false }
+smlang = "0.5.1"
+enum-iterator = "0.7.0"
 
 [profile.dev]
 opt-level = 3

--- a/src/hardware/ad7172.rs
+++ b/src/hardware/ad7172.rs
@@ -1,6 +1,8 @@
 // (AD7172 https://www.analog.com/media/en/technical-documentation/data-sheets/AD7172-2.pdf)
 
 use core::fmt::Debug;
+use defmt::Format;
+use num_enum::TryFromPrimitive;
 
 use super::hal::hal::blocking::spi::{Transfer, Write};
 
@@ -47,6 +49,28 @@ pub mod Comms {
     pub mod RW {
         pub const WRITE: u32 = 0 << 6;
         pub const READ: u32 = 1 << 6;
+    }
+}
+
+#[derive(Clone, Copy, TryFromPrimitive, Debug, Format)]
+#[repr(usize)]
+pub enum AdcChannel {
+    Zero = 0,
+    One = 1,
+    Two = 2,
+    Three = 3,
+}
+
+pub struct Status(u8);
+impl Status {
+    pub fn channel(&self) -> AdcChannel {
+        AdcChannel::try_from(self.0 as usize & 0x3).unwrap()
+    }
+}
+
+impl From<u8> for Status {
+    fn from(x: u8) -> Self {
+        Self(x)
     }
 }
 

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -328,16 +328,16 @@ impl StateMachineContext for Adc {
     /// again once it has finished
     /// sampling (or when it is selected if it is done at this point) and the routine will start again.
     fn next(&mut self, phy: &AdcPhy, ch: &AdcChannel) -> AdcPhy {
-        self.rdyn.clear_interrupt_pending_bit();
         self.set_cs(*phy, PinState::High);
+        self.rdyn.clear_interrupt_pending_bit();
         let next = phy.next(ch);
         self.set_cs(next, PinState::Low);
         next
     }
 
     fn stop(&mut self, phy: &AdcPhy) {
-        self.rdyn.clear_interrupt_pending_bit();
         self.set_cs(*phy, PinState::High);
+        self.rdyn.clear_interrupt_pending_bit();
     }
 }
 

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -322,7 +322,7 @@ impl StateMachineContext for Adc {
     }
 
     /// Uses the schedule implemented in `AdcPhy::next()` to decide which ADC will have data ready next.
-    /// It then clears the interupt pending flag
+    /// It clears the interupt pending flag
     /// (which does not trigger an interrupt right away since the currently selected ADC does not have new data),
     /// deselects the current ADC and selects the next in line. The next ADC will then trigger the interrupt
     /// again once it has finished

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -75,7 +75,7 @@ impl From<AdcCode> for f64 {
             relative_voltage / (1.0 - relative_voltage) * AdcCode::R_REF_N as f64;
         let temperature_kelvin_inv =
             1.0 / AdcCode::T_N as f64 + 1.0 / AdcCode::B as f64 * relative_resistance.ln();
-        (1.0 / temperature_kelvin_inv) - AdcCode::ZERO_C as f64
+        1.0 / temperature_kelvin_inv - AdcCode::ZERO_C as f64
     }
 }
 

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -315,7 +315,7 @@ statemachine! {
 impl StateMachineContext for Adc {
     /// The data readout has to be initiated by selecting the first ADC.
     fn start(&mut self) -> AdcPhy {
-        // set up sampling sequence by selection first ADC according to schedule
+        // set up sampling sequence by selecting the first ADC according to schedule
         self.rdyn.clear_interrupt_pending_bit();
         self.set_cs(AdcPhy::Zero, PinState::Low);
         AdcPhy::Zero

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -31,8 +31,14 @@ impl AdcCode {
     const R_REF: f32 = 2.0 * 5000.0; // Ratiometric resistor setup. 5.0K high and low side.
     const ZERO_C: f32 = 273.15; // 0°C in °K
     const B: f32 = 3988.0; // NTC beta value. TODO: This should probaply be changeable.
-    const T_N: f32 = 25.0; // Reference Temperature for B-parameter equation.
+    const T_N: f32 = 25.0 + AdcCode::ZERO_C; // Reference Temperature for B-parameter equation.
     const R_N: f32 = 10000.0; // TEC resistance at T_N.
+
+    // ADC relative full scale per LSB
+    // Inverted equation from datasheet p. 40 with V_Ref normalized to 1 as this cancels out in resistance.
+    const FS_PER_LSB: f32 = 0x400000 as f32 / (2.0 * (1 << 23) as f32 * AdcCode::GAIN * 0.75);
+    // Relative resistance
+    const R_REF_N_1: f32 = AdcCode::R_REF / AdcCode::R_N - 1.0;
 }
 
 impl From<u32> for AdcCode {
@@ -56,41 +62,25 @@ impl From<AdcCode> for f32 {
     /// * Resistor setup as on Thermostat-EEM
     /// * Imput values not close to minimum/maximum (~1000 codes difference)
     fn from(code: AdcCode) -> f32 {
-        // Inverted equation from datasheet p. 40 with V_Ref normalized to 1 as this cancels out in resistance.
-        let relative_voltage =
-            (code.0 as f32) * ((0x400000 as f32) / (2.0 * (1 << 23) as f32 * AdcCode::GAIN * 0.75));
+        let u = code.0 as f32 * AdcCode::FS_PER_LSB;
         // Voltage divider normalized to V_Ref = 1, inverted to get to NTC resistance.
-        let relative_resistance =
-            (relative_voltage) / (1.0 - relative_voltage) * (AdcCode::R_REF / AdcCode::R_N);
+        let r = 1.0 / u - 2.0;
         // https://en.wikipedia.org/wiki/Thermistor#B_or_%CE%B2_parameter_equation
-        let temperature_kelvin_inv = 1.0 / (AdcCode::T_N + AdcCode::ZERO_C)
-            + (1.0 / AdcCode::B) * (relative_resistance).ln();
-        (1.0 / temperature_kelvin_inv) - AdcCode::ZERO_C
+        let t = (1.0 / AdcCode::T_N + AdcCode::R_REF_N_1.ln_1p() / AdcCode::B)
+            - 1.0 / AdcCode::B * r.ln_1p();
+        1.0 / t - AdcCode::ZERO_C
     }
 }
 
 impl From<AdcCode> for f64 {
-    /// Convert raw ADC codes to temperature value in °C using the AD7172 input voltage to code
-    /// relation, the ratiometric resistor setup and the "B-parameter" equation (a simple form of the
-    /// Steinhart-Hart equation). This is a treadeoff between computation and absolute temperature
-    /// accuracy. The f64 dataformat should not limit the dynamic range or produce significant arithmetic
-    /// errors.
-    /// Valid under the following conditions:
-    /// * Unipolar ADC input
-    /// * Unchanged ADC GAIN and OFFSET registers (default reset values)
-    /// * Resistor setup as on Thermostat-EEM
-    /// * Imput values not close to minimum/maximum (~1000 codes difference)
+    /// Like `From<AdcCode> for f32` but for `f64` and correspondingly higher dynamic rande.
     fn from(code: AdcCode) -> f64 {
-        // Inverted equation from datasheet p. 40 with V_Ref normalized to 1 as this cancels out in resistance.
-        let relative_voltage = (code.0 as f64)
-            * ((0x400000 as f64) / (2.0 * (1 << 23) as f64 * AdcCode::GAIN as f64 * 0.75));
-        // Voltage divider normalized to V_Ref = 1, inverted to get to NTC resistance.
-        let relative_resistance = (relative_voltage) / (1.0 - relative_voltage)
-            * (AdcCode::R_REF as f64 / AdcCode::R_N as f64);
+        let u = code.0 as f64 * AdcCode::FS_PER_LSB as f64;
+        let r = 1.0 / u - 2.0;
         // https://en.wikipedia.org/wiki/Thermistor#B_or_%CE%B2_parameter_equation
-        let temperature_kelvin_inv = 1.0 / (AdcCode::T_N as f64 + AdcCode::ZERO_C as f64)
-            + (1.0 / AdcCode::B as f64) * (relative_resistance).ln();
-        (1.0 / temperature_kelvin_inv) - AdcCode::ZERO_C as f64
+        let t = (1.0 / AdcCode::T_N + AdcCode::R_REF_N_1.ln_1p() / AdcCode::B) as f64
+            - (1.0 / AdcCode::B) as f64 * r.ln_1p();
+        1.0 / t - AdcCode::ZERO_C as f64
     }
 }
 

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -31,8 +31,14 @@ impl AdcCode {
     const R_REF: f32 = 2.0 * 5000.0; // Ratiometric resistor setup. 5.0K high and low side.
     const ZERO_C: f32 = 273.15; // 0°C in °K
     const B: f32 = 3988.0; // NTC beta value. TODO: This should probaply be changeable.
-    const T_N: f32 = 25.0; // Reference Temperature for B-parameter equation.
+    const T_N: f32 = 25.0 + AdcCode::ZERO_C; // Reference Temperature for B-parameter equation.
     const R_N: f32 = 10000.0; // TEC resistance at T_N.
+
+    // ADC relative full scale per LSB
+    // Inverted equation from datasheet p. 40 with V_Ref normalized to 1 as this cancels out in resistance.
+    const FS_PER_LSB: f32 = 0x400000 as f32 / (2.0 * (1 << 23) as f32 * AdcCode::GAIN * 0.75);
+    // Relative resistance
+    const R_REF_N: f32 = AdcCode::R_REF / AdcCode::R_N;
 }
 
 impl From<u32> for AdcCode {
@@ -56,40 +62,24 @@ impl From<AdcCode> for f32 {
     /// * Resistor setup as on Thermostat-EEM
     /// * Imput values not close to minimum/maximum (~1000 codes difference)
     fn from(code: AdcCode) -> f32 {
-        // Inverted equation from datasheet p. 40 with V_Ref normalized to 1 as this cancels out in resistance.
-        let relative_voltage =
-            (code.0 as f32) * ((0x400000 as f32) / (2.0 * (1 << 23) as f32 * AdcCode::GAIN * 0.75));
+        let relative_voltage = code.0 as f32 * AdcCode::FS_PER_LSB;
         // Voltage divider normalized to V_Ref = 1, inverted to get to NTC resistance.
-        let relative_resistance =
-            (relative_voltage) / (1.0 - relative_voltage) * (AdcCode::R_REF / AdcCode::R_N);
+        let relative_resistance = relative_voltage / (1.0 - relative_voltage) * AdcCode::R_REF_N;
         // https://en.wikipedia.org/wiki/Thermistor#B_or_%CE%B2_parameter_equation
-        let temperature_kelvin_inv = 1.0 / (AdcCode::T_N + AdcCode::ZERO_C)
-            + (1.0 / AdcCode::B) * (relative_resistance).ln();
-        (1.0 / temperature_kelvin_inv) - AdcCode::ZERO_C
+        let temperature_kelvin_inv =
+            1.0 / AdcCode::T_N + 1.0 / AdcCode::B * relative_resistance.ln();
+        1.0 / temperature_kelvin_inv - AdcCode::ZERO_C
     }
 }
 
 impl From<AdcCode> for f64 {
-    /// Convert raw ADC codes to temperature value in °C using the AD7172 input voltage to code
-    /// relation, the ratiometric resistor setup and the "B-parameter" equation (a simple form of the
-    /// Steinhart-Hart equation). This is a treadeoff between computation and absolute temperature
-    /// accuracy. The f64 dataformat should not limit the dynamic range or produce significant arithmetic
-    /// errors.
-    /// Valid under the following conditions:
-    /// * Unipolar ADC input
-    /// * Unchanged ADC GAIN and OFFSET registers (default reset values)
-    /// * Resistor setup as on Thermostat-EEM
-    /// * Imput values not close to minimum/maximum (~1000 codes difference)
+    /// Like `From<AdcCode> for f32` but for `f64` and correspondingly higher dynamic rande.
     fn from(code: AdcCode) -> f64 {
-        // Inverted equation from datasheet p. 40 with V_Ref normalized to 1 as this cancels out in resistance.
-        let relative_voltage = (code.0 as f64)
-            * ((0x400000 as f64) / (2.0 * (1 << 23) as f64 * AdcCode::GAIN as f64 * 0.75));
-        // Voltage divider normalized to V_Ref = 1, inverted to get to NTC resistance.
-        let relative_resistance = (relative_voltage) / (1.0 - relative_voltage)
-            * (AdcCode::R_REF as f64 / AdcCode::R_N as f64);
-        // https://en.wikipedia.org/wiki/Thermistor#B_or_%CE%B2_parameter_equation
-        let temperature_kelvin_inv = 1.0 / (AdcCode::T_N as f64 + AdcCode::ZERO_C as f64)
-            + (1.0 / AdcCode::B as f64) * (relative_resistance).ln();
+        let relative_voltage = (code.0 as f32 * AdcCode::FS_PER_LSB) as f64;
+        let relative_resistance =
+            relative_voltage / (1.0 - relative_voltage) * AdcCode::R_REF_N as f64;
+        let temperature_kelvin_inv =
+            1.0 / AdcCode::T_N as f64 + 1.0 / AdcCode::B as f64 * relative_resistance.ln();
         (1.0 / temperature_kelvin_inv) - AdcCode::ZERO_C as f64
     }
 }

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Hardware specific setup etc.
 
+use enum_iterator::IntoEnumIterator;
 use num_enum::TryFromPrimitive;
 pub use stm32h7xx_hal as hal;
 
@@ -40,7 +41,7 @@ pub type NetworkManager = smoltcp_nal::shared::NetworkManager<
 
 pub type EthernetPhy = hal::ethernet::phy::LAN8742A<hal::ethernet::EthernetMAC>;
 
-#[derive(Clone, Copy, TryFromPrimitive)]
+#[derive(Clone, Copy, TryFromPrimitive, IntoEnumIterator)]
 #[repr(usize)]
 pub enum OutputChannel {
     Zero = 0,

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -41,7 +41,7 @@ pub type NetworkManager = smoltcp_nal::shared::NetworkManager<
 
 pub type EthernetPhy = hal::ethernet::phy::LAN8742A<hal::ethernet::EthernetMAC>;
 
-#[derive(Clone, Copy, TryFromPrimitive, IntoEnumIterator)]
+#[derive(Clone, Copy, TryFromPrimitive, IntoEnumIterator, defmt::Format)]
 #[repr(usize)]
 pub enum OutputChannel {
     Zero = 0,

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -321,6 +321,10 @@ pub fn setup(
     // Enable interrupt after all ADC setup is done.
     // *Note*: Race condition: If the first ADC already sampled more than once by this point
     // the interrupt readout sequence breaks.
+    //
+    // TODO
+    // With the new self-aligning statemachine ADC sequencer, this can likely be moved into `Adc`
+    // and made non-pub.
     adc.rdyn.enable_interrupt(&mut exti);
 
     info!("Setup Ethernet");

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -5,7 +5,7 @@ use stm32h7xx_hal::hal::digital::v2::OutputPin;
 use super::hal::{
     self as hal,
     ethernet::{self, PHY},
-    gpio::{Edge, ExtiPin, GpioExt},
+    gpio::GpioExt,
     prelude::*,
 };
 use crate::hardware::SRC_MAC;
@@ -293,11 +293,7 @@ pub fn setup(
     // enable MCO 2MHz clock output to ADCs
     gpioa.pa8.into_alternate_af0();
 
-    let mut rdyn = gpioc.pc11.into_pull_up_input();
-    rdyn.make_interrupt_source(&mut device.SYSCFG);
-    rdyn.trigger_on_edge(&mut device.EXTI, Edge::Falling);
-    rdyn.enable_interrupt(&mut device.EXTI);
-    let adc = Adc::new(
+    let mut adc_sm = StateMachine::new(Adc::new(
         &mut delay,
         &ccdr.clocks,
         ccdr.peripheral.SPI4,
@@ -314,11 +310,11 @@ pub fn setup(
                 gpioe.pe3.into_push_pull_output(),
                 gpioe.pe4.into_push_pull_output(),
             ),
-            rdyn,
+            rdyn: gpioc.pc11.into_pull_up_input(),
             sync: gpiob.pb11.into_push_pull_output(),
         },
-    );
-    let adc_sm = StateMachine::new(adc);
+    ));
+    adc_sm.start(&mut device.EXTI, &mut device.SYSCFG);
 
     info!("Setup Ethernet");
     let mac_addr = smoltcp::wire::EthernetAddress(SRC_MAC);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use panic_probe as _; // gloibal panic handler
 use defmt::{info, Format};
 use enum_iterator::IntoEnumIterator;
 use hardware::{
-    adc::{Adc, AdcCode, Events, InputChannel, StateMachine},
+    adc::{Adc, AdcCode, InputChannel, StateMachine},
     adc_internal::AdcInternal,
     dac::Dac,
     gpio::{Gpio, Led, PoePower},
@@ -150,7 +150,7 @@ mod app {
         let clock = SystemTimer::new(|| monotonics::now().ticks());
 
         // setup Thermostat hardware
-        let mut thermostat = hardware::setup::setup(c.device, clock);
+        let thermostat = hardware::setup::setup(c.device, clock);
 
         let mono = Systick::new(systick, thermostat.clocks.sysclk().0);
 
@@ -171,7 +171,6 @@ mod app {
         ethernet_link::spawn().unwrap();
         settings_update::spawn(settings).unwrap();
         telemetry_task::spawn().unwrap();
-        thermostat.adc_sm.process_event(Events::Start).unwrap();
 
         let local = Local {
             adc_sm: thermostat.adc_sm,


### PR DESCRIPTION
* wrap the adc into a state machine
* automatic schedule alignment
* build some infrastructure for non-homogeneous schedules
* also refactor the AdcPhy usage and InputChannel functionality
* add AdcChannel to enumerate the ad7172 config "channel"
* clean up some temperature conversion math and remove unnecessary parentheses
* remove unnecessary and redundant comments
* clean up imports and make them more explicit to avoid ambiguities
* use enum iterators

* [ ] not tested on hardware, especially interrupt setup/initial clear/enable