### PR TITLE
Use log/rtt-target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,8 +5,6 @@ rustflags = [
     "-C", "link-arg=-Tlink.x",
     "-C", "link-arg=--nmagic",
     "-C", "target-cpu=cortex-m7",
-    "-C", "link-arg=-Tdefmt.x",
-    "-C", "target-feature=+fp-armv8d16",
 ]
 
 [build]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,45 +201,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a0ae7494d9bff013d7b89471f4c424356a71e9752e0c78abe7e6c608a16bb3"
-dependencies = [
- "bitflags",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8500cbe4cca056412efce4215a63d0bc20492942aeee695f23b624a53e0a6854"
-dependencies = [
- "defmt-parser",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db23d29972d99baa3de2ee2ae3f104c10564a6d05a346eb3f4c4f2c0525a06e"
-
-[[package]]
-name = "defmt-rtt"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2cbbbd58847d508d97629b32cd9730a2d28532f71e219714614406029f18b1"
-dependencies = [
- "critical-section",
- "defmt",
-]
-
-[[package]]
 name = "derive_miniconf"
 version = "0.5.0"
 source = "git+https://github.com/quartiq/miniconf?rev=3a07a7f#3a07a7ffbaa238c34613a1171790a60d5f5b696c"
@@ -624,7 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab1f00eac22bd18f8e5cae9555f2820b3a0c166b5b556ee3e203746ea6dcf3a"
 dependencies = [
  "cortex-m 0.7.6",
- "defmt",
+ "rtt-target",
 ]
 
 [[package]]
@@ -735,6 +696,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "rtt-logger"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c83752c03884a6a08abe7aa352f468ff2dc2b3dd4e5a32bdcc34b1cfbef4b6b"
+dependencies = [
+ "log",
+ "rtt-target",
+]
+
+[[package]]
+name = "rtt-target"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065d6058bb1204f51a562a67209e1817cf714759d5cf845aa45c75fa7b0b9d9b"
+dependencies = [
+ "cortex-m 0.7.6",
+ "ufmt-write",
 ]
 
 [[package]]
@@ -985,8 +966,6 @@ dependencies = [
  "cortex-m 0.7.6",
  "cortex-m-rt",
  "cortex-m-rtic",
- "defmt",
- "defmt-rtt",
  "embedded-time",
  "enum-iterator 1.2.0",
  "heapless",
@@ -997,6 +976,8 @@ dependencies = [
  "num-traits",
  "num_enum",
  "panic-probe",
+ "rtt-logger",
+ "rtt-target",
  "serde",
  "serde-json-core",
  "shared-bus-rtic",
@@ -1011,6 +992,12 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m = { version = "0.7" }
 cortex-m-rt = { version = "0.7", features = ["device"] }
 stm32h7xx-hal =  { version = "0.13.0", features = ["stm32h743v", "rt", "ethernet"]}
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
-panic-probe = { version = "0.3.0", features = ["print-defmt"] }
+panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 asm-delay = "0.9.0"
 smoltcp-nal = { version = "0.2", features = ["shared-stack"] }
 cortex-m-rtic = "1.0.0"
@@ -30,8 +30,8 @@ minimq = "0.5.2"
 serde = { version = "1.0.147", features = ["derive"], default-features = false }
 serde-json-core = "0.4"
 num_enum = { version = "0.5.6", default-features = false }
-defmt = "0.3.0"
-defmt-rtt = "0.3.0"
+rtt-logger = "0.2"
+rtt-target = { version = "0.3", features = ["cortex-m"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 shared-bus-rtic = { version = "0.2", features = ["cortex-m"] }
 byteorder = { version = "1", default-features = false }

--- a/src/hardware/ad7172.rs
+++ b/src/hardware/ad7172.rs
@@ -1,7 +1,6 @@
 // (AD7172 https://www.analog.com/media/en/technical-documentation/data-sheets/AD7172-2.pdf)
 
 use core::fmt::Debug;
-use defmt::Format;
 use num_enum::TryFromPrimitive;
 
 use super::hal::hal::blocking::spi::{Transfer, Write};
@@ -52,7 +51,7 @@ pub mod Comms {
     }
 }
 
-#[derive(Clone, Copy, TryFromPrimitive, Debug, Format)]
+#[derive(Clone, Copy, TryFromPrimitive, Debug)]
 #[repr(usize)]
 pub enum AdcChannel {
     Zero = 0,

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -1,6 +1,5 @@
 // Thermostat ADC struct.
 
-use defmt::Format;
 use enum_iterator::{all, Sequence};
 use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
 use smlang::statemachine;
@@ -19,7 +18,7 @@ use super::hal::{
 use num_traits::float::Float;
 
 /// A type representing an ADC sample.
-#[derive(Copy, Clone, Debug, Format)]
+#[derive(Copy, Clone, Debug)]
 pub struct AdcCode(u32);
 impl AdcCode {
     const GAIN: f32 = 0x555555 as _; // Default ADC gain from datasheet.
@@ -85,7 +84,7 @@ impl From<AdcCode> for f64 {
     }
 }
 
-#[derive(Clone, Copy, TryFromPrimitive, Debug, Format, PartialEq, Eq, Sequence)]
+#[derive(Clone, Copy, TryFromPrimitive, Debug, PartialEq, Eq, Sequence)]
 #[repr(usize)]
 pub enum InputChannel {
     Zero = 0,
@@ -108,7 +107,7 @@ impl TryFrom<(AdcPhy, AdcChannel)> for InputChannel {
     }
 }
 
-#[derive(Clone, Copy, TryFromPrimitive, Debug, Format, Sequence)]
+#[derive(Clone, Copy, TryFromPrimitive, Debug, Sequence)]
 #[repr(usize)]
 pub enum AdcPhy {
     Zero = 0,
@@ -237,7 +236,7 @@ impl Adc {
         let id = self.adcs.read(ad7172::AdcReg::ID);
         // check that ID is 0x00DX, as per datasheet
         if id & 0xfff0 != 0x00d0 {
-            defmt::error!("invalid ID: {=u32:#x}", id);
+            log::error!("invalid ID: {:#x}", id);
             return Err(Error::Ident);
         }
 

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -19,7 +19,6 @@ use super::hal::{
 };
 
 use super::OutputChannelIdx;
-use defmt::Format;
 
 // Note: Up to 30MHz clock valid according to DAC datasheet. This lead to spurious RxFIFO overruns on the STM side when probing the spi clock with a scope probe.
 const SPI_CLOCK: MegaHertz = MegaHertz::MHz(8);
@@ -35,7 +34,7 @@ pub enum Error {
 }
 
 /// A type representing a DAC sample.
-#[derive(Copy, Clone, Debug, Format)]
+#[derive(Copy, Clone, Debug)]
 pub struct DacCode(u32);
 impl DacCode {
     // DAC constants

--- a/src/hardware/gpio.rs
+++ b/src/hardware/gpio.rs
@@ -5,7 +5,6 @@ use super::hal::{
     hal::digital::v2::PinState,
 };
 use crate::net::serde::Serialize;
-use defmt::Format;
 
 use super::OutputChannelIdx;
 
@@ -46,7 +45,7 @@ impl From<State> for PinState {
     }
 }
 
-#[derive(Copy, Clone, Debug, Serialize, Format)]
+#[derive(Copy, Clone, Debug, Serialize)]
 pub enum PoePower {
     /// No Power over Ethernet detected
     Absent,

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -41,7 +41,7 @@ pub type NetworkManager = smoltcp_nal::shared::NetworkManager<
 
 pub type EthernetPhy = hal::ethernet::phy::LAN8742A<hal::ethernet::EthernetMAC>;
 
-#[derive(Clone, Copy, TryFromPrimitive, Sequence, defmt::Format, Debug)]
+#[derive(Clone, Copy, TryFromPrimitive, Sequence, Debug)]
 #[repr(usize)]
 pub enum OutputChannelIdx {
     Zero = 0,

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -155,7 +155,7 @@ pub fn setup(
         log::set_logger(&LOGGER)
             .map(|()| log::set_max_level(log::LevelFilter::Trace))
             .unwrap();
-        log::info!("Starting");
+        log::info!("Start logging");
     }
     let pwr = device.PWR.constrain();
     let vos = pwr.freeze();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,6 @@ pub mod net;
 pub mod output_channel;
 pub mod statistics;
 
-use defmt_rtt as _;
-// global logger
 use panic_probe as _; // global panic handler
 
 use enum_iterator::all;
@@ -277,7 +275,7 @@ mod app {
                     let t = !(limits[0]..limits[1]).contains(&(temp as f32));
                     c.shared.telemetry.lock(|tele| tele.monitor.alarm[i] = t);
                     if t {
-                        defmt::error!("channel {:?} temperature out of range, Alarm tripped!", i);
+                        log::error!("channel {:?} temperature out of range, Alarm tripped!", i);
                     }
                     t
                 });


### PR DESCRIPTION
I would really like to go back to using log/rtt-target for logging for the following reasons:
- It is consistent with Stabilizer/Driver
- I always forget that I have to supply command line options if I want any prints at all and it takes me minutes to figure out why I don't get prints
- The `Format` trait for defmt is often not implemented and I therefore I sometimes can't print the things I want
- I sank some time into getting defmt 0.4 to work but something breaks at linking and I didn't make much progress there