### PR TITLE
implement settings finalization

### DIFF
--- a/src/hardware/pwm.rs
+++ b/src/hardware/pwm.rs
@@ -77,7 +77,7 @@ impl Pwm {
     // PWM constants
     const MAX_DUTY: u32 = 10000; // Maximum duty cycle valid for all channels.
     const V_PWM: f32 = 3.3; // MCU PWM pin output high voltage
-    pub const MAX_CURRENT_LIMIT: f32 = 3.0; // As per MAX1968 datasheet
+    pub const MAX_CURRENT_LIMIT: f64 = 3.0; // As per MAX1968 datasheet
     pub const MAX_VOLTAGE_LIMIT: f32 = 4.3; // As per MAX1968 datasheet
 
     /// Construct a new PWM driver for all Thermostat output channel limits.

--- a/src/hardware/pwm.rs
+++ b/src/hardware/pwm.rs
@@ -77,7 +77,7 @@ impl Pwm {
     // PWM constants
     const MAX_DUTY: u32 = 10000; // Maximum duty cycle valid for all channels.
     const V_PWM: f32 = 3.3; // MCU PWM pin output high voltage
-    pub const MAX_CURRENT_LIMIT: f64 = 3.0; // As per MAX1968 datasheet
+    pub const MAX_CURRENT_LIMIT: f64 = 3.0; // As per MAX1968 datasheet. (Pwm::V_PWM * 0.15) / (VREF_TEC * R_SENSE) for 100% duty cycle equivalent.
     pub const MAX_VOLTAGE_LIMIT: f32 = 4.3; // As per MAX1968 datasheet
 
     /// Construct a new PWM driver for all Thermostat output channel limits.

--- a/src/hardware/pwm.rs
+++ b/src/hardware/pwm.rs
@@ -78,6 +78,7 @@ impl Pwm {
     const MAX_DUTY: u32 = 10000; // Maximum duty cycle valid for all channels.
     const V_PWM: f32 = 3.3; // MCU PWM pin output high voltage
     pub const MAX_CURRENT_LIMIT: f32 = (Pwm::V_PWM * 0.15) / (VREF_TEC * R_SENSE);
+    pub const MAX_VOLTAGE_LIMIT: f32 = 4.3; // As per MAX1968 datasheet
 
     /// Construct a new PWM driver for all Thermostat output channel limits.
     ///

--- a/src/hardware/pwm.rs
+++ b/src/hardware/pwm.rs
@@ -77,7 +77,7 @@ impl Pwm {
     // PWM constants
     const MAX_DUTY: u32 = 10000; // Maximum duty cycle valid for all channels.
     const V_PWM: f32 = 3.3; // MCU PWM pin output high voltage
-    pub const MAX_CURRENT_LIMIT: f32 = (Pwm::V_PWM * 0.15) / (VREF_TEC * R_SENSE);
+    pub const MAX_CURRENT_LIMIT: f32 = 3.0; // As per MAX1968 datasheet
     pub const MAX_VOLTAGE_LIMIT: f32 = 4.3; // As per MAX1968 datasheet
 
     /// Construct a new PWM driver for all Thermostat output channel limits.

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,17 +201,12 @@ mod app {
 
         let pwm = c.local.pwm;
         for ch in all::<OutputChannelIdx>() {
-            let s = settings.output_channel[ch as usize];
-            // set current limits to 5% higher/lower than iir y_max/y_min and clamp output to valid range.
-            let current_limit_positive =
-                (s.iir.y_max as f32 + 0.05 * 3.0).clamp(0.0, Pwm::MAX_CURRENT_LIMIT);
-            let current_limit_negative =
-                (s.iir.y_min as f32 - 0.05 * 3.0).clamp(-Pwm::MAX_CURRENT_LIMIT, 0.0);
-            // TODO: implement what happens if user chooses invalid voltage limit. currently just panick.
+            let mut s = settings.output_channel[ch as usize];
+            s.finalize_settings(); // clamp limits and normalize weights
             pwm.set_limit(Limit::Voltage(ch), s.voltage_limit).unwrap();
-            pwm.set_limit(Limit::PositiveCurrent(ch), current_limit_positive)
+            pwm.set_limit(Limit::PositiveCurrent(ch), s.iir.y_max as f32)
                 .unwrap();
-            pwm.set_limit(Limit::NegativeCurrent(ch), current_limit_negative)
+            pwm.set_limit(Limit::NegativeCurrent(ch), s.iir.y_min as f32)
                 .unwrap();
             c.shared.gpio.lock(|gpio| {
                 gpio.set_shutdown(ch, s.shutdown.into());

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,10 +204,17 @@ mod app {
             let mut s = settings.output_channel[ch as usize];
             s.finalize_settings(); // clamp limits and normalize weights
             pwm.set_limit(Limit::Voltage(ch), s.voltage_limit).unwrap();
-            pwm.set_limit(Limit::PositiveCurrent(ch), s.iir.y_max as f32)
-                .unwrap();
-            pwm.set_limit(Limit::NegativeCurrent(ch), s.iir.y_min as f32)
-                .unwrap();
+            // give 5% extra headroom for PWM current limits
+            pwm.set_limit(
+                Limit::PositiveCurrent(ch),
+                s.iir.y_max as f32 + 0.05 * Pwm::MAX_CURRENT_LIMIT,
+            )
+            .unwrap();
+            pwm.set_limit(
+                Limit::NegativeCurrent(ch),
+                s.iir.y_min as f32 - 0.05 * Pwm::MAX_CURRENT_LIMIT,
+            )
+            .unwrap();
             c.shared.gpio.lock(|gpio| {
                 gpio.set_shutdown(ch, s.shutdown.into());
                 gpio.set_led(ch.into(), (!s.shutdown).into()) // fix leds to channel state

--- a/src/output_channel.rs
+++ b/src/output_channel.rs
@@ -104,6 +104,8 @@ impl OutputChannel {
             }
         }
         [
+            // [Pwm::MAX_CURRENT_LIMIT] + 5% is still below 100% duty cycle for the PWM limits and therefore OK.
+            // Might not be OK for a different shunt resistor or different PWM setup.
             (self.iir.y_max + 0.05 * Pwm::MAX_CURRENT_LIMIT).min(0.) as f32,
             (self.iir.y_min - 0.05 * Pwm::MAX_CURRENT_LIMIT).max(0.) as f32,
         ]


### PR DESCRIPTION
Small PR for output settings finalization. I also included the limits to be consistent with "invisible" mutations of miniconf settings.
I think it makes sense to limit the iir limits too so that we get not unexpected windup. Clamping the volatge limit is also better than a panic obviously.
closes https://github.com/quartiq/thermostat-eem/issues/37