### PR TITLE
* Settings.Alarm.period in SI units * Default for Alarm for readability * several resources don't need to be option arrays * dac resource can be local * drop some iter.flatten.zip chains for readability * reduce lock duration in telemetry_task (for statistics_buffer) * fix alarm telemetry * move alarm tele out of monitor * reduce lock duration of alarm tele

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -174,7 +174,7 @@ pub fn get_device_prefix(
 ///
 /// The alarm is non-latching. If alarm was "true" for a while and the temperatures come within
 /// limits again, alarm will be "false" again.
-#[derive(Clone, Debug, Miniconf)]
+#[derive(Clone, Debug, Miniconf, Default)]
 pub struct Alarm {
     /// Set the alarm to armed (true) or disarmed (false).
     /// If the alarm is armed, the device will publish it's alarm state onto the [target].
@@ -195,8 +195,8 @@ pub struct Alarm {
     /// The alarm will publish its state with this period.
     ///
     /// # Value
-    /// u64
-    pub period_ms: u64,
+    /// f32
+    pub period: f32,
 
     /// Temperature limits for the alarm.
     ///


### PR DESCRIPTION
Untested!
