### PR TITLE
Feature/dependency updates

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,10 +1,11 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip STM32H743ZITx --speed 30000"
+runner = "probe-rs run --chip STM32H743ZITx --log-file /dev/null"
 # runner = "gdb-multiarch -q -x openocd.gdb"
 rustflags = [
     "-C", "link-arg=-Tlink.x",
     "-C", "link-arg=--nmagic",
     "-C", "target-cpu=cortex-m7",
+    #"-C", "target-feature=+fp-armv8d16",
 ]
 
 [build]

--- a/.cargo/config
+++ b/.cargo/config
@@ -5,7 +5,9 @@ rustflags = [
     "-C", "link-arg=-Tlink.x",
     "-C", "link-arg=--nmagic",
     "-C", "target-cpu=cortex-m7",
-    #"-C", "target-feature=+fp-armv8d16",
+    "-C", "target-feature=+fp-armv8d16",
+    # fp-armv8d16 is unstable and not a rustc feature but accurate
+    # fp-armv8 is unstable and a rustc feature but incorrect
 ]
 
 [build]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
       time: "04:00"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: Continuous Integration
-
 on:
+  merge_group:
   push:
-    
+    branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # UTC
+    - cron: '48 4 * * *'
 env:
   CARGO_TERM_COLOR: always
 
@@ -33,6 +36,7 @@ jobs:
         with:
           command: check
           args: --verbose
+
       - uses: actions/setup-python@v1
         with:
           python-version: 3.8
@@ -47,17 +51,62 @@ jobs:
 
   compile:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
       matrix:
-        toolchain: [stable]
+        # keep MSRV in sync in ci.yaml and Cargo.toml
+        toolchain: [stable, '1.66.1']
+        features: ['']
+        continue-on-error: [false]
+        include:
+          - toolchain: beta
+            features: ''
+            continue-on-error: true
+          - toolchain: nightly
+            features: nightly
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.toolchain }}
           target: thumbv7em-none-eabihf
           override: true
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --release --features "${{ matrix.features }}"
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install Deadlinks
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: |
+            cargo-deadlinks
+
+      - name: cargo doc
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps -p miniconf -p idsp -p thermostat-eem
+
+      - name: cargo deadlinks
+        uses: actions-rs/cargo@v1
+        with:
+          command: deadlinks
+          # We intentionally ignore fragments, as RTIC may generate fragments for various
+          # auto-generated code.
+          args: --dir target/thumbv7em-none-eabihf/doc --ignore-fragments --check-intra-doc-links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased](https://github.com/quartiq/thermostat-eem/compare/v0.1.0...master)
+
+### Changed
+* A DNS name for the MQTT broker of `mqtt` is now used instead of a hard-coded IP address.
+* A static IP can be assigned to Thermostat using the `STATIC_IP` environment variable at build
+  time. If one is not specified, DHCP is used automatically.
+* Miniconf versions have been updated to v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * A static IP can be assigned to Thermostat using the `STATIC_IP` environment variable at build
   time. If one is not specified, DHCP is used automatically.
 * Miniconf versions have been updated to v0.9.0
+* Application metadata is now published to the `<prefix>/meta` topic on MQTT connections

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -268,22 +268,22 @@ dependencies = [
 
 [[package]]
 name = "enum-iterator"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706d9e7cf1c7664859d79cd524e4e53ea2b67ea03c98cc2870c5e539695d597e"
+checksum = "9fd242f399be1da0a5354aa462d57b4ab2b4ee0683cc552f7c007d2d12d36e94"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f93763ef7b0ae1c43c4d8eccc9d5848d84ad1a1d8ce61c421d1ac85a19d05"
+checksum = "03cdc46ec28bd728e67540c528013c6a10eb69a02eb31078a1bda695438cbfb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -483,12 +483,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "managed"
@@ -527,7 +524,7 @@ checksum = "89f46d25f40e41f552d76b8eb9e225fe493ebf978a5c3f42b7599e45cfe6b4e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -540,7 +537,7 @@ dependencies = [
  "embedded-nal",
  "embedded-time",
  "heapless",
- "num_enum 0.7.2",
+ "num_enum",
  "serde",
  "smlang",
  "varint-rs",
@@ -639,21 +636,12 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive 0.5.11",
 ]
 
 [[package]]
@@ -662,18 +650,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
- "num_enum_derive 0.7.2",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
+ "num_enum_derive",
 ]
 
 [[package]]
@@ -684,7 +661,7 @@ checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -892,9 +869,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -912,13 +889,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.4",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -1040,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.4"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c622ae390c9302e214c31013517c2061ecb2699935882c60a9b37f82f8625ae"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1077,7 +1054,7 @@ dependencies = [
  "miniconf",
  "minimq",
  "num-traits",
- "num_enum 0.5.11",
+ "num_enum",
  "panic-probe",
  "rtt-logger",
  "rtt-target",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c041a8d9751a520ee19656232a18971f18946a7900f1520ee4400002244dd89"
 dependencies = [
- "critical-section",
+ "critical-section 0.2.7",
 ]
 
 [[package]]
@@ -136,6 +136,7 @@ checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
+ "critical-section 1.1.2",
  "embedded-hal",
  "volatile-register",
 ]
@@ -201,6 +202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
+
+[[package]]
 name = "embedded-dma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,15 +227,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "embedded-nal"
-version = "0.6.0"
+name = "embedded-io"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9efecb57ab54fa918730f2874d7d37647169c50fa1357fecb81abee840b113"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-nal"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447416d161ba378782c13e82b11b267d6d2104b4913679a7c5640e7e94f96ea7"
 dependencies = [
  "heapless",
  "nb 1.0.0",
  "no-std-net",
 ]
+
+[[package]]
+name = "embedded-storage"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
 
 [[package]]
 name = "embedded-time"
@@ -406,9 +425,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniconf"
-version = "0.6.3"
-source = "git+https://github.com/quartiq/miniconf#8be449dcd9be7c838720c21223dac0841595dd26"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df2d7bdba3acb28460c347b21e1e88d869f2716ebe060eb6a79f7b76b57de72"
 dependencies = [
+ "embedded-io",
  "heapless",
  "itoa",
  "log",
@@ -421,25 +442,26 @@ dependencies = [
 
 [[package]]
 name = "miniconf_derive"
-version = "0.6.2"
-source = "git+https://github.com/quartiq/miniconf#8be449dcd9be7c838720c21223dac0841595dd26"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f46d25f40e41f552d76b8eb9e225fe493ebf978a5c3f42b7599e45cfe6b4e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.4",
 ]
 
 [[package]]
 name = "minimq"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b222dbc2667cc69a2d9acdf5c24280c49233295eda3a767f6ddfb4040f5cc80c"
+checksum = "b561c2c86a3509f7c514f546fb24755753a30fdcf67cce8d5f2f38688483cd31"
 dependencies = [
  "bit_field",
  "embedded-nal",
  "embedded-time",
  "heapless",
- "num_enum",
+ "num_enum 0.7.2",
  "serde",
  "smlang",
  "varint-rs",
@@ -468,9 +490,9 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "no-std-net"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bcece43b12349917e096cddfa66107277f123e6c96a5aea78711dc601a47152"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "num"
@@ -552,7 +574,16 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive 0.7.2",
 ]
 
 [[package]]
@@ -564,6 +595,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.4",
 ]
 
 [[package]]
@@ -608,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -768,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ec3c8fe427f45ee3aaa0ebb9f0d9ab8ae9ad05d12047fe7249ae5ea9374ff0"
+checksum = "3c9e1ab533c0bc414c34920ec7e5f097101d126ed5eac1a1aac711222e0bbb33"
 dependencies = [
  "heapless",
  "ryu",
@@ -833,20 +875,22 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72165c4af59f5f19c7fb774b88b95660591b612380305b5f4503157341a9f7ee"
+checksum = "8d2e3a36ac8fea7b94e666dfa3871063d6e0a5c9d5d4fec9a1a6b7b6760f0229"
 dependencies = [
  "bitflags",
  "byteorder",
+ "cfg-if",
+ "heapless",
  "managed",
 ]
 
 [[package]]
 name = "smoltcp-nal"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a63a94229e438f53c83757c51b346a09409064f6d18723e0393e11d829b09640"
+checksum = "6dd2ed2f8e7643a170506863ed0f52ad1dc5762abdcff27de825dde14fc8025f"
 dependencies = [
  "embedded-nal",
  "embedded-time",
@@ -885,16 +929,16 @@ dependencies = [
 
 [[package]]
 name = "stm32h7xx-hal"
-version = "0.13.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74a1d83bf1e19db5e504c2cb2d98e7ca5f7ff758ca69f44cf6bfddc90af30dc"
+checksum = "e08bcfbdbe4458133f2fd55994a5c4f1b4bf28084f0218e93cdbc19d7c70219f"
 dependencies = [
  "bare-metal 1.0.0",
- "bitflags",
  "cast",
  "cortex-m 0.7.7",
  "embedded-dma",
  "embedded-hal",
+ "embedded-storage",
  "fugit",
  "nb 1.0.0",
  "paste",
@@ -953,7 +997,7 @@ dependencies = [
  "miniconf",
  "minimq",
  "num-traits",
- "num_enum",
+ "num_enum 0.5.11",
  "panic-probe",
  "rtt-logger",
  "rtt-target",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "idsp"
-version = "0.9.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f2a7a4a8265bedb4b15abf376c0e9eb2def6290868709894efc27633b04618"
+checksum = "8f255ee573949fb629362d10aa3abd0a97a7c4950a3b8890b435b8c7516cf38f"
 dependencies = [
  "num-complex 0.4.2",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,17 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asm-delay"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a69a963b70ddacfcd382524f72a4576f359af9334b3bf48a79566590bb8bfa"
-dependencies = [
- "bitrate",
- "cortex-m 0.7.7",
- "embedded-hal",
-]
-
-[[package]]
 name = "atomic-polyfill"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,12 +85,6 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
-
-[[package]]
-name = "bitrate"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c147d86912d04bef727828fda769a76ca81629a46d8ba311a8d58a26aa91473d"
 
 [[package]]
 name = "built"
@@ -951,17 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared-bus-rtic"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1899470d03c5728db375f63be8f2bbfb93d8c35ec932061f3b593434c2273b"
-dependencies = [
- "cortex-m 0.6.7",
- "embedded-hal",
- "nb 1.0.0",
-]
-
-[[package]]
 name = "smlang"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,7 +1064,6 @@ dependencies = [
 name = "thermostat-eem"
 version = "0.1.0"
 dependencies = [
- "asm-delay",
  "built",
  "byteorder",
  "cortex-m 0.7.7",
@@ -1112,7 +1083,6 @@ dependencies = [
  "rtt-target",
  "serde",
  "serde-json-core",
- "shared-bus-rtic",
  "smlang",
  "smoltcp-nal",
  "stm32h7xx-hal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,10 +92,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "bitrate"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c147d86912d04bef727828fda769a76ca81629a46d8ba311a8d58a26aa91473d"
+
+[[package]]
+name = "built"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d17f4d6e4dc36d1a02fbedc2753a096848e7c1b0772f7654eab8e2c927dd53"
+dependencies = [
+ "git2",
+]
 
 [[package]]
 name = "byteorder"
@@ -108,6 +123,16 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "jobserver",
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -279,6 +304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fugit"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +359,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +398,16 @@ dependencies = [
  "serde",
  "spin",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -381,16 +438,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "jobserver"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "libc"
+version = "0.2.153"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.16.1+1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -623,6 +719,18 @@ name = "paste"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "proc-macro-error"
@@ -879,7 +987,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d2e3a36ac8fea7b94e666dfa3871063d6e0a5c9d5d4fec9a1a6b7b6760f0229"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "cfg-if",
  "heapless",
@@ -985,6 +1093,7 @@ name = "thermostat-eem"
 version = "0.1.0"
 dependencies = [
  "asm-delay",
+ "built",
  "byteorder",
  "cortex-m 0.7.7",
  "cortex-m-rt",
@@ -1011,6 +1120,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,10 +1147,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "varint-rs"
@@ -1039,6 +1189,12 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cortex-m = { version = "0.7" }
 cortex-m-rt = { version = "0.7", features = ["device"] }
 stm32h7xx-hal =  { version = "0.15.1", features = ["stm32h743v", "rt", "ethernet"]}
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
-panic-probe = { version = "0.3.0", features = ["print-rtt"] }
+panic-probe = { version = "=0.3.0", features = ["print-rtt"] }
 smoltcp-nal = { version = "0.4", features = ["shared-stack"] }
 cortex-m-rtic = "1.1.4"
 embedded-time = "0.12.1"
@@ -32,13 +32,13 @@ heapless = { version = "0.7", features = ["serde"] }
 minimq = "0.8"
 serde = { version = "1.0.158", features = ["derive"], default-features = false }
 serde-json-core = "0.5"
-num_enum = { version = "0.5.11", default-features = false }
+num_enum = { version = "0.7.2", default-features = false }
 rtt-logger = "0.2"
 rtt-target = { version = "0.3", features = ["cortex-m"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 byteorder = { version = "1", default-features = false }
 smlang = "0.6.0"
-enum-iterator = "1.4.0"
+enum-iterator = "1.5.0"
 idsp = "0.9.2"
 
 # Note: Keep in-sync with `py/setup.py`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ cortex-m-rt = { version = "0.7", features = ["device"] }
 stm32h7xx-hal =  { version = "0.15.1", features = ["stm32h743v", "rt", "ethernet"]}
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
-asm-delay = "0.9.0"
 smoltcp-nal = { version = "0.4", features = ["shared-stack"] }
 cortex-m-rtic = "1.1.4"
 embedded-time = "0.12.1"
@@ -37,7 +36,6 @@ num_enum = { version = "0.5.11", default-features = false }
 rtt-logger = "0.2"
 rtt-target = { version = "0.3", features = ["cortex-m"] }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-shared-bus-rtic = { version = "0.2", features = ["cortex-m"] }
 byteorder = { version = "1", default-features = false }
 smlang = "0.6.0"
 enum-iterator = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ byteorder = { version = "1", default-features = false }
 smlang = "0.6.0"
 enum-iterator = "1.4.0"
 idsp = "0.9.2"
+
+# Note: Keep in-sync with `py/setup.py`
 miniconf = "0.9"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ai_artiq = []
 [dependencies]
 cortex-m = { version = "0.7" }
 cortex-m-rt = { version = "0.7", features = ["device"] }
-stm32h7xx-hal =  { version = "0.15.1", features = ["stm32h743v", "rt", "ethernet", "xspi"]}
+stm32h7xx-hal =  { version = "0.15.1", features = ["stm32h743v", "rt", "ethernet"]}
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 asm-delay = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 byteorder = { version = "1", default-features = false }
 smlang = "0.6.0"
 enum-iterator = "1.5.0"
-idsp = "0.9.2"
+idsp = "0.14.1"
 
 # Note: Keep in-sync with `py/setup.py`
 miniconf = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,17 +21,16 @@ ai_artiq = []
 [dependencies]
 cortex-m = { version = "0.7" }
 cortex-m-rt = { version = "0.7", features = ["device"] }
-stm32h7xx-hal =  { version = "0.13.1", features = ["stm32h743v", "rt", "ethernet"]}
+stm32h7xx-hal =  { version = "0.15.1", features = ["stm32h743v", "rt", "ethernet", "xspi"]}
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_info"] }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 asm-delay = "0.9.0"
-smoltcp-nal = { version = "0.2", features = ["shared-stack"] }
+smoltcp-nal = { version = "0.4", features = ["shared-stack"] }
 cortex-m-rtic = "1.1.4"
 embedded-time = "0.12.1"
-miniconf = "0.6.3"
 systick-monotonic = "1.0.1"
 heapless = { version = "0.7", features = ["serde"] }
-minimq = "0.6.2"
+minimq = "0.8"
 serde = { version = "1.0.158", features = ["derive"], default-features = false }
 serde-json-core = "0.5"
 num_enum = { version = "0.5.11", default-features = false }
@@ -43,6 +42,7 @@ byteorder = { version = "1", default-features = false }
 smlang = "0.6.0"
 enum-iterator = "1.4.0"
 idsp = "0.9.2"
+miniconf = "0.9"
 
 [profile.dev]
 opt-level = 3
@@ -52,5 +52,3 @@ opt-level = 3
 lto = true
 codegen-units = 1
 
-[patch.crates-io]
-miniconf = { git = "https://github.com/quartiq/miniconf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,5 @@ opt-level = 3
 lto = true
 codegen-units = 1
 
+[build-dependencies]
+built = { version = "0.7", features = ["git2"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,18 @@
 name = "thermostat-eem"
 version = "0.1.0"
 edition = "2021"
-authors = ["Norman Krackow <nk@quartiq.de>", "Robert Jördens", "Ryan Summers"]
+authors = ["Norman Krackow <nk@quartiq.de>", "Robert Jördens <rj@quartiq.de>", "Ryan Summers"]
 description = "Firmware for the Sinara Thermostat-EEM temperature controller."
 categories = ["embedded", "no-std", "hardware-support", "science"]
 license = "MIT OR Apache-2.0"
-keywords = ["stm32h7", "physics", "adc", "dac", "dsp", "control systems"]
+keywords = ["ethernet", "stm32h7", "adc", "dac", "physics"]
 repository = "https://github.com/quartiq/thermostat-eem"
 readme = "README.md"
 exclude = [
 	".gitignore"
 ]
+# keep MSRV in sync in ci.yaml and Cargo.toml
+rust-version = "1.66.1"
 
 [features]
 default = ["all_differential"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/py/setup.py
+++ b/py/setup.py
@@ -14,6 +14,7 @@ setup(
     license="MIT",
     install_requires=[
         "stabilizer@git+https://github.com/quartiq/stabilizer@f4055aa#subdirectory=py",
-        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@8be449d#subdirectory=py/miniconf-mqtt",
+        # Note: Keep in-sync with `Cargo.toml`
+        "miniconf-mqtt@git+https://github.com/quartiq/miniconf@v0.9.0#subdirectory=py/miniconf-mqtt",
     ],
 )

--- a/py/setup.py
+++ b/py/setup.py
@@ -13,7 +13,7 @@ setup(
     author="QUARTIQ GmbH",
     license="MIT",
     install_requires=[
-        "stabilizer@git+https://github.com/quartiq/stabilizer@f4055aa#subdirectory=py",
+        "stabilizer@git+https://github.com/quartiq/stabilizer@d25f2efaaa598eb1a47ceed409f7179d7031f4c0#subdirectory=py",
         # Note: Keep in-sync with `Cargo.toml`
         "miniconf-mqtt@git+https://github.com/quartiq/miniconf@v0.9.0#subdirectory=py/miniconf-mqtt",
     ],

--- a/py/thermostat/configure_output_ch.py
+++ b/py/thermostat/configure_output_ch.py
@@ -168,9 +168,9 @@ def _main():
             f"/output_channel/{args.channel}/iir",
             {
                 "ba": coefficients,
-                "y_offset": args.y_offset + forward_gain * args.x_offset,
-                "y_min": args.y_min,
-                "y_max": args.y_max,
+                "u": args.y_offset + forward_gain * args.x_offset,
+                "min": args.y_min,
+                "max": args.y_max,
             },
         )
         for i, weight in enumerate(args.input_weights):

--- a/py/thermostat/configure_output_ch.py
+++ b/py/thermostat/configure_output_ch.py
@@ -23,7 +23,7 @@ def _main():
         "--broker",
         "-b",
         type=str,
-        default="10.42.0.1",
+        default="mqtt",
         help="The MQTT broker to use to communicate with "
         "Thermostat-EEM (%(default)s)",
     )
@@ -152,19 +152,19 @@ def _main():
         interface = await miniconf.Miniconf.create(prefix, args.broker)
 
         # Set the filter coefficients.
-        await interface.command(
+        await interface.set(
             f"output_channel/{args.channel}/shutdown",
             args.shutdown,
         )
-        await interface.command(
+        await interface.set(
             f"output_channel/{args.channel}/hold",
             args.hold,
         )
-        await interface.command(
+        await interface.set(
             f"output_channel/{args.channel}/voltage_limit",
             args.voltage_limit,
         )
-        await interface.command(
+        await interface.set(
             f"output_channel/{args.channel}/iir",
             {
                 "ba": coefficients,
@@ -174,7 +174,7 @@ def _main():
             },
         )
         for i, weight in enumerate(args.input_weights):
-            await interface.command(
+            await interface.set(
                 f"output_channel/{args.channel}/weights/{i}",
                 weight,
             )

--- a/py/thermostat/configure_output_ch.py
+++ b/py/thermostat/configure_output_ch.py
@@ -153,19 +153,19 @@ def _main():
 
         # Set the filter coefficients.
         await interface.set(
-            f"output_channel/{args.channel}/shutdown",
+            f"/output_channel/{args.channel}/shutdown",
             args.shutdown,
         )
         await interface.set(
-            f"output_channel/{args.channel}/hold",
+            f"/output_channel/{args.channel}/hold",
             args.hold,
         )
         await interface.set(
-            f"output_channel/{args.channel}/voltage_limit",
+            f"/output_channel/{args.channel}/voltage_limit",
             args.voltage_limit,
         )
         await interface.set(
-            f"output_channel/{args.channel}/iir",
+            f"/output_channel/{args.channel}/iir",
             {
                 "ba": coefficients,
                 "y_offset": args.y_offset + forward_gain * args.x_offset,
@@ -175,7 +175,7 @@ def _main():
         )
         for i, weight in enumerate(args.input_weights):
             await interface.set(
-                f"output_channel/{args.channel}/weights/{i}",
+                f"/output_channel/{args.channel}/weights/{i}",
                 weight,
             )
 

--- a/src/hardware/adc.rs
+++ b/src/hardware/adc.rs
@@ -197,7 +197,7 @@ impl Adc {
         Ok(adc)
     }
 
-    /// Setup all ADCs to the specifies [config].
+    /// Setup all ADCs to the specifies [AdcConfig].
     fn setup(&mut self, delay: &mut impl DelayUs<u16>, config: AdcConfig) -> Result<(), Error> {
         // deassert all CS first
         for pin in self.cs.iter_mut() {

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -1,15 +1,14 @@
-///! Thermostat DAC driver
-///!
-///! This file contains the driver for the 4 Thermostat DAC output channels.
-///! To convert a 18 bit word into an analog current Thermostat uses a DAC to
-///! convert the word into a voltage and a subsequent TEC driver IC that produces
-///! a current proportional to the DAC voltage.
-///!
-///! The 4 channel DAC ICs share an SPI bus and are addressed using individual "sync"
-///! signals, similar to a chip select signal.
-///! DAC datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/AD5680.pdf
-///! TEC driver datasheet: https://datasheets.maximintegrated.com/en/ds/MAX1968-MAX1969.pdf
-///!
+/// Thermostat DAC driver
+///
+/// This file contains the driver for the 4 Thermostat DAC output channels.
+/// To convert a 18 bit word into an analog current Thermostat uses a DAC to
+/// convert the word into a voltage and a subsequent TEC driver IC that produces
+/// a current proportional to the DAC voltage.
+///
+/// The 4 channel DAC ICs share an SPI bus and are addressed using individual "sync"
+/// signals, similar to a chip select signal.
+/// DAC datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/AD5680.pdf
+/// TEC driver datasheet: https://datasheets.maximintegrated.com/en/ds/MAX1968-MAX1969.pdf
 use super::hal::{
     gpio::{self, gpioc},
     hal::blocking::spi::Write,

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -1,14 +1,16 @@
-/// Thermostat DAC driver
-///
-/// This file contains the driver for the 4 Thermostat DAC output channels.
-/// To convert a 18 bit word into an analog current Thermostat uses a DAC to
-/// convert the word into a voltage and a subsequent TEC driver IC that produces
-/// a current proportional to the DAC voltage.
-///
-/// The 4 channel DAC ICs share an SPI bus and are addressed using individual "sync"
-/// signals, similar to a chip select signal.
-/// DAC datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/AD5680.pdf
-/// TEC driver datasheet: https://datasheets.maximintegrated.com/en/ds/MAX1968-MAX1969.pdf
+//! Thermostat DAC driver
+//!
+//! This file contains the driver for the 4 Thermostat DAC output channels.
+//! To convert a 18 bit word into an analog current Thermostat uses a DAC to
+//! convert the word into a voltage and a subsequent TEC driver IC that produces
+//! a current proportional to the DAC voltage.
+//!
+//! The 4 channel DAC ICs share an SPI bus and are addressed using individual "sync"
+//! signals, similar to a chip select signal.
+//! DAC datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/AD5680.pdf
+//! TEC driver datasheet: https://datasheets.maximintegrated.com/en/ds/MAX1968-MAX1969.pdf
+//!
+
 use super::hal::{
     gpio::{self, gpioc},
     hal::blocking::spi::Write,

--- a/src/hardware/dac.rs
+++ b/src/hardware/dac.rs
@@ -7,8 +7,8 @@
 //!
 //! The 4 channel DAC ICs share an SPI bus and are addressed using individual "sync"
 //! signals, similar to a chip select signal.
-//! DAC datasheet: https://www.analog.com/media/en/technical-documentation/data-sheets/AD5680.pdf
-//! TEC driver datasheet: https://datasheets.maximintegrated.com/en/ds/MAX1968-MAX1969.pdf
+//! DAC datasheet: `<https://www.analog.com/media/en/technical-documentation/data-sheets/AD5680.pdf>`
+//! TEC driver datasheet: `<https://datasheets.maximintegrated.com/en/ds/MAX1968-MAX1969.pdf>`
 //!
 
 use super::hal::{
@@ -71,8 +71,8 @@ impl From<DacCode> for u32 {
 
 /// DAC gpio pins.
 ///
-/// sync[<n>] - DAC IC adressing signals
-/// * <n> specifies Thermostat output channel
+/// `sync[n]` - DAC IC adressing signals
+///   where `n` specifies Thermostat output channel
 pub struct DacPins {
     pub sync: [gpio::ErasedPin<gpio::Output>; 4],
 }

--- a/src/hardware/metadata.rs
+++ b/src/hardware/metadata.rs
@@ -6,6 +6,7 @@ mod build_info {
 
 #[derive(Serialize)]
 pub struct ApplicationMetadata {
+    pub app: &'static str,
     pub firmware_version: &'static str,
     pub rust_version: &'static str,
     pub profile: &'static str,
@@ -23,7 +24,8 @@ impl ApplicationMetadata {
     /// A reference to the global metadata.
     pub fn new() -> &'static ApplicationMetadata {
         cortex_m::singleton!(: ApplicationMetadata = ApplicationMetadata {
-            firmware_version: build_info::GIT_VERSION.unwrap_or("Unspecified"),
+            app: env!("CARGO_BIN_NAME"),
+            firmware_version: build_info::GIT_VERSION.unwrap_or(build_info::PKG_VERSION),
             rust_version: build_info::RUSTC_VERSION,
             profile: build_info::PROFILE,
             git_dirty: build_info::GIT_DIRTY.unwrap_or(false),

--- a/src/hardware/metadata.rs
+++ b/src/hardware/metadata.rs
@@ -1,0 +1,34 @@
+use serde::Serialize;
+
+mod build_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+#[derive(Serialize)]
+pub struct ApplicationMetadata {
+    pub firmware_version: &'static str,
+    pub rust_version: &'static str,
+    pub profile: &'static str,
+    pub git_dirty: bool,
+    pub features: &'static str,
+}
+
+impl ApplicationMetadata {
+    /// Construct the global metadata.
+    ///
+    /// # Note
+    /// This may only be called once.
+    ///
+    /// # Returns
+    /// A reference to the global metadata.
+    pub fn new() -> &'static ApplicationMetadata {
+        cortex_m::singleton!(: ApplicationMetadata = ApplicationMetadata {
+            firmware_version: build_info::GIT_VERSION.unwrap_or("Unspecified"),
+            rust_version: build_info::RUSTC_VERSION,
+            profile: build_info::PROFILE,
+            git_dirty: build_info::GIT_DIRTY.unwrap_or(false),
+            features: build_info::FEATURES_STR,
+        })
+        .unwrap()
+    }
+}

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -25,13 +25,13 @@ const RX_DESRING_CNT: usize = 4;
 
 pub type NetworkStack = smoltcp_nal::NetworkStack<
     'static,
-    hal::ethernet::EthernetDMA<'static, TX_DESRING_CNT, RX_DESRING_CNT>,
+    hal::ethernet::EthernetDMA<TX_DESRING_CNT, RX_DESRING_CNT>,
     system_timer::SystemTimer,
 >;
 
 pub type NetworkManager = smoltcp_nal::shared::NetworkManager<
     'static,
-    hal::ethernet::EthernetDMA<'static, TX_DESRING_CNT, RX_DESRING_CNT>,
+    hal::ethernet::EthernetDMA<TX_DESRING_CNT, RX_DESRING_CNT>,
     system_timer::SystemTimer,
 >;
 

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -13,6 +13,7 @@ pub mod dac;
 pub mod delay;
 pub mod fan;
 pub mod gpio;
+pub mod metadata;
 pub mod pwm;
 pub mod setup;
 pub mod system_timer;

--- a/src/hardware/pwm.rs
+++ b/src/hardware/pwm.rs
@@ -1,7 +1,8 @@
-/// Thermostat TEC driver IC voltage/current limits PWM driver.
-///
-/// The Thermostat TEC driver ICs feature current limits controlled by an analog voltage input.
-/// This voltage is controlled by the MCU using low-pass filtered PWM outputs.
+//! Thermostat TEC driver IC voltage/current limits PWM driver.
+//!
+//! The Thermostat TEC driver ICs feature current limits controlled by an analog voltage input.
+//! This voltage is controlled by the MCU using low-pass filtered PWM outputs.
+//!
 use super::{
     dac::{R_SENSE, VREF_TEC},
     hal::{

--- a/src/hardware/pwm.rs
+++ b/src/hardware/pwm.rs
@@ -36,10 +36,10 @@ pub enum Error {
 
 /// Pwm pins.
 ///
-/// voltage<n> - voltage limit pin
-/// positive_current<n> - positive current limit pin
-/// negative_current<n> - negative current limit pin
-/// * <n> specifies Thermostat output channel
+/// `voltage.<n>` - voltage limit pin
+/// `positive_current.<n>` - positive current limit pin
+/// `negative_current.<n>` - negative current limit pin
+/// * `<n>` specifies Thermostat output channel
 #[allow(clippy::type_complexity)]
 pub struct PwmPins {
     pub voltage: (

--- a/src/hardware/pwm.rs
+++ b/src/hardware/pwm.rs
@@ -1,8 +1,7 @@
-///! Thermostat TEC driver IC voltage/current limits PWM driver.
-///!
-///! The Thermostat TEC driver ICs feature current limits controlled by an analog voltage input.
-///! This voltage is controlled by the MCU using low-pass filtered PWM outputs.
-///!
+/// Thermostat TEC driver IC voltage/current limits PWM driver.
+///
+/// The Thermostat TEC driver ICs feature current limits controlled by an analog voltage input.
+/// This voltage is controlled by the MCU using low-pass filtered PWM outputs.
 use super::{
     dac::{R_SENSE, VREF_TEC},
     hal::{

--- a/src/hardware/setup.rs
+++ b/src/hardware/setup.rs
@@ -20,6 +20,7 @@ use super::{
     delay,
     fan::{Fan, FanPins},
     gpio::{Gpio, GpioPins},
+    metadata::ApplicationMetadata,
     pwm::{Pwm, PwmPins},
     EthernetPhy, NetworkStack,
 };
@@ -107,6 +108,7 @@ pub struct ThermostatDevices {
     pub adc_internal: AdcInternal,
     pub adc_sm: StateMachine<Adc>,
     pub adc_channels: [[bool; 4]; 4],
+    pub metadata: &'static ApplicationMetadata,
 }
 
 #[link_section = ".sram3.eth"]
@@ -612,5 +614,6 @@ pub fn setup(
         adc_internal,
         adc_sm,
         adc_channels,
+        metadata: ApplicationMetadata::new(),
     }
 }

--- a/src/hardware/system_timer.rs
+++ b/src/hardware/system_timer.rs
@@ -1,8 +1,8 @@
-/// System timer used for non-RTIC compatibility
-///
-/// # Design
-///  `Clock` is implemented using the RTIC `app::monotonics::now()` default `Monotonic`.
-///  That `Monotonic` must tick at 1 kHz.
+//! System timer used for non-RTIC compatibility
+//!
+//! # Design
+//!  `Clock` is implemented using the RTIC `app::monotonics::now()` default `Monotonic`.
+//!  That `Monotonic` must tick at 1 kHz.
 use minimq::embedded_time::{clock::Error, fraction::Fraction, Clock, Instant};
 
 #[derive(Copy, Clone, Debug)]

--- a/src/hardware/system_timer.rs
+++ b/src/hardware/system_timer.rs
@@ -1,8 +1,8 @@
-///! System timer used for non-RTIC compatibility
-///!
-///! # Design
-///!  `Clock` is implemented using the RTIC `app::monotonics::now()` default `Monotonic`.
-///!  That `Monotonic` must tick at 1 kHz.
+/// System timer used for non-RTIC compatibility
+///
+/// # Design
+///  `Clock` is implemented using the RTIC `app::monotonics::now()` default `Monotonic`.
+///  That `Monotonic` must tick at 1 kHz.
 use minimq::embedded_time::{clock::Error, fraction::Fraction, Clock, Instant};
 
 #[derive(Copy, Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,10 +164,11 @@ mod app {
                 if thermostat.adc_channels[phy_i][ch_i] {
                     telemetry.alarm[phy_i][ch_i] = Some(false);
                     telemetry.statistics[phy_i][ch_i] = Some(Default::default());
-                    settings.alarm.temperature_limits[phy_i][ch_i] = Some([f32::MIN, f32::MAX]);
+                    settings.alarm.temperature_limits[phy_i][ch_i] =
+                        Some([f32::NEG_INFINITY, f32::INFINITY]);
                     // Initialize the output weights.
                     for ch in settings.output_channel.iter_mut() {
-                        ch.weights[phy_i][ch_i] = Some(0.);
+                        ch.weights[phy_i][ch_i] = 0.;
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ pub struct Settings {
     ///
     /// # Value
     /// See [output_channel::OutputChannel]
-    #[tree(depth(5))]
+    #[tree(depth(4))]
     output_channel: [output_channel::OutputChannel; 4],
 
     /// Alarm settings.
@@ -63,7 +63,7 @@ pub struct Settings {
     ///
     /// # Value
     /// See [Alarm]
-    #[tree(depth(3))]
+    #[tree(depth(5))]
     alarm: Alarm,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,7 @@ mod app {
             &id,
             option_env!("BROKER").unwrap_or("mqtt"),
             settings.clone(),
+            thermostat.metadata,
         );
 
         settings_update::spawn(settings.clone()).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ impl Default for Settings {
     fn default() -> Self {
         Self {
             telemetry_period: 1.0,
-            output_channel: [Default::default(); 4].into(),
+            output_channel: [Default::default(); 4],
             alarm: Alarm {
                 period: 1.0,
                 ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,7 @@ pub struct Settings {
     ///
     /// # Path
     /// `output_channel/<n>`
-    /// * <n> specifies which channel to configure. <n> := [0, 1, 2, 3]
+    /// * `<n> := [0, 1, 2, 3]` specifies which channel to configure.
     ///
     /// # Value
     /// See [output_channel::OutputChannel]
@@ -62,7 +62,7 @@ pub struct Settings {
     ///
     /// # Value
     /// See [Alarm]
-    #[tree(depth(5))]
+    #[tree(depth(3))]
     alarm: Alarm,
 }
 
@@ -89,7 +89,7 @@ pub struct Monitor {
     output_current: [f32; 4],
     /// Measurement of the output voltages.
     output_voltage: [f32; 4],
-    /// See [PoEPower]
+    /// See [PoePower]
     poe: PoePower,
     /// Overtemperature status.
     overtemp: bool,
@@ -100,9 +100,9 @@ pub struct Monitor {
 pub struct Telemetry {
     /// see [Monitor]
     monitor: Monitor,
-    /// [<adc>][<channel>] array of [Statistics]. 'None' for disabled channels.
+    /// `[<adc>][<channel>]` array of [Statistics]. `None` for disabled channels.
     statistics: [[Option<Statistics>; 4]; 4],
-    /// Alarm status for each enabled input channel. 'None' for disabled channels.
+    /// Alarm status for each enabled input channel. `None` for disabled channels.
     alarm: [[Option<bool>; 4]; 4],
     /// Output current in Amperes for each Thermostat output channel.
     output_current: [f32; 4],
@@ -117,7 +117,7 @@ mod app {
 
     #[shared]
     struct Shared {
-        network: NetworkUsers<Settings, Telemetry, 6>,
+        network: NetworkUsers<Settings, Telemetry, 5>,
         settings: Settings,
         telemetry: Telemetry,
         gpio: Gpio,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,18 +13,33 @@ pub mod network_processor;
 pub mod telemetry;
 
 use crate::hardware::{system_timer::SystemTimer, EthernetPhy, NetworkManager, NetworkStack};
-use minimq::embedded_nal::IpAddr;
 use network_processor::NetworkProcessor;
 use telemetry::TelemetryClient;
 
 use core::fmt::Write;
 use heapless::String;
-use miniconf::Miniconf;
+use miniconf::{JsonCoreSlash, Tree};
 use serde::Serialize;
 
 pub type NetworkReference = smoltcp_nal::shared::NetworkStackProxy<'static, NetworkStack>;
 
+// TODO: Check buffer sizes.
+pub struct MqttStorage {
+    telemetry: [u8; 2048],
+    settings: [u8; 1024],
+}
+
+impl Default for MqttStorage {
+    fn default() -> Self {
+        Self {
+            telemetry: [0u8; 2048],
+            settings: [0u8; 1024],
+        }
+    }
+}
+
 /// The default MQTT broker IP address if unspecified.
+/// TODO: Figure out how to use this?
 pub const DEFAULT_MQTT_BROKER: [u8; 4] = [10, 34, 16, 10];
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -33,22 +48,32 @@ pub enum UpdateState {
     Updated,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum NetworkState {
-    SettingsChanged,
+    SettingsChanged(String<128>),
     Updated,
     NoChange,
 }
 /// A structure of Stabilizer's default network users.
-pub struct NetworkUsers<S: Default + Miniconf + Clone, T: Serialize> {
-    pub miniconf: miniconf::MqttClient<S, NetworkReference, SystemTimer, 512>,
+pub struct NetworkUsers<S, T, const Y: usize>
+where
+    for<'de> S: Default + JsonCoreSlash<'de, Y> + Clone,
+    T: Serialize,
+{
+    pub miniconf: miniconf::MqttClient<
+        'static,
+        S,
+        NetworkReference,
+        SystemTimer,
+        miniconf::minimq::broker::NamedBroker<NetworkReference>,
+        Y,
+    >,
     pub processor: NetworkProcessor,
     pub telemetry: TelemetryClient<T>,
 }
 
-impl<S, T> NetworkUsers<S, T>
+impl<S, T, const Y: usize> NetworkUsers<S, T, Y>
 where
-    S: Default + Miniconf + Clone,
+    for<'de> S: Default + JsonCoreSlash<'de, Y> + Clone,
     T: Serialize,
 {
     /// Construct Stabilizer's default network users.
@@ -60,6 +85,7 @@ where
     /// * `app` - The name of the application.
     /// * `mac` - The MAC address of the network.
     /// * `broker` - The IP address of the MQTT broker to use.
+    /// * `id` - The MQTT client ID base to use.
     /// * `settings` - The initial settings value
     ///
     /// # Returns
@@ -69,8 +95,8 @@ where
         phy: EthernetPhy,
         clock: SystemTimer,
         app: &str,
-        mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
-        broker: IpAddr,
+        id: &str,
+        broker: &str,
         settings: S,
     ) -> Self {
         let stack_manager =
@@ -78,25 +104,43 @@ where
 
         let processor = NetworkProcessor::new(stack_manager.acquire_stack(), phy);
 
-        let prefix = get_device_prefix(app, mac);
+        let prefix = get_device_prefix(app, id);
+
+        let store = cortex_m::singleton!(: MqttStorage = MqttStorage::default()).unwrap();
+
+        let named_broker =
+            miniconf::minimq::broker::NamedBroker::new(broker, stack_manager.acquire_stack())
+                .unwrap();
 
         let settings = miniconf::MqttClient::new(
             stack_manager.acquire_stack(),
-            &get_client_id(app, "settings", mac),
             &prefix,
-            broker,
             clock,
             settings,
+            miniconf::minimq::ConfigBuilder::new(named_broker, &mut store.settings)
+                .client_id(&get_client_id(id, "settings"))
+                .unwrap(),
         )
         .unwrap();
 
-        let telemetry = TelemetryClient::new(
-            stack_manager.acquire_stack(),
-            clock,
-            &get_client_id(app, "tlm", mac),
-            &prefix,
-            broker,
-        );
+        let telemetry = {
+            let named_broker =
+                miniconf::minimq::broker::NamedBroker::new(broker, stack_manager.acquire_stack())
+                    .unwrap();
+
+            let mqtt = minimq::Minimq::new(
+                stack_manager.acquire_stack(),
+                clock,
+                minimq::ConfigBuilder::new(named_broker, &mut store.telemetry)
+                    // The telemetry client doesn't receive any messages except MQTT control packets.
+                    // As such, we don't need much of the buffer for RX.
+                    .rx_buffer(minimq::config::BufferConfig::Maximum(100))
+                    .client_id(&get_client_id(id, "tlm"))
+                    .unwrap(),
+            );
+
+            TelemetryClient::new(mqtt, &prefix)
+        };
 
         NetworkUsers {
             miniconf: settings,
@@ -119,8 +163,13 @@ where
             UpdateState::Updated => NetworkState::Updated,
         };
 
-        match self.miniconf.update() {
-            Ok(true) => NetworkState::SettingsChanged,
+        let mut settings_path: String<128> = String::new();
+        match self.miniconf.handled_update(|path, old, new| {
+            settings_path = path.into();
+            *old = new.clone();
+            Result::<(), &'static str>::Ok(())
+        }) {
+            Ok(true) => NetworkState::SettingsChanged(settings_path),
             _ => poll_result,
         }
     }
@@ -129,19 +178,14 @@ where
 /// Get an MQTT client ID for a client.
 ///
 /// # Args
-/// * `app` - The name of the application
-/// * `client` - The unique tag of the client
-/// * `mac` - The MAC address of the device.
+/// * `id` - The base client ID
+/// * `mode` - The operating mode of the client. (i.e. tlm, settings)
 ///
 /// # Returns
 /// A client ID that may be used for MQTT client identification.
-fn get_client_id(
-    app: &str,
-    client: &str,
-    mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
-) -> String<64> {
+fn get_client_id(id: &str, mode: &str) -> String<64> {
     let mut identifier = String::new();
-    write!(&mut identifier, "{}-{}-{}", app, mac, client).unwrap();
+    write!(&mut identifier, "{id}-{mode}").unwrap();
     identifier
 }
 
@@ -149,18 +193,15 @@ fn get_client_id(
 ///
 /// # Args
 /// * `app` - The name of the application that is executing.
-/// * `mac` - The ethernet MAC address of the device.
+/// * `id` - The MQTT ID of the device.
 ///
 /// # Returns
 /// The MQTT prefix used for this device.
-pub fn get_device_prefix(
-    app: &str,
-    mac: smoltcp_nal::smoltcp::wire::EthernetAddress,
-) -> String<128> {
+pub fn get_device_prefix(app: &str, id: &str) -> String<128> {
     // Note(unwrap): The mac address + binary name must be short enough to fit into this string. If
     // they are defined too long, this will panic and the device will fail to boot.
     let mut prefix: String<128> = String::new();
-    write!(&mut prefix, "dt/sinara/{}/{}", app, mac).unwrap();
+    write!(&mut prefix, "dt/sinara/{app}/{id}").unwrap();
 
     prefix
 }
@@ -174,7 +215,7 @@ pub fn get_device_prefix(
 ///
 /// The alarm is non-latching. If alarm was "true" for a while and the temperatures come within
 /// limits again, alarm will be "false" again.
-#[derive(Clone, Debug, Miniconf, Default)]
+#[derive(Clone, Debug, Tree, Default)]
 pub struct Alarm {
     /// Set the alarm to armed (true) or disarmed (false).
     /// If the alarm is armed, the device will publish it's alarm state onto the [target].
@@ -211,6 +252,6 @@ pub struct Alarm {
     ///
     /// # Value
     /// [f32, f32]
-    #[miniconf(defer)]
-    pub temperature_limits: miniconf::Array<miniconf::Array<Option<[f32; 2]>, 4>, 4>,
+    #[tree(depth(2))]
+    pub temperature_limits: [[Option<[f32; 2]>; 4]; 4],
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -80,7 +80,6 @@ where
     /// * `stack` - The network stack that will be used to share with all network users.
     /// * `phy` - The ethernet PHY connecting the network.
     /// * `clock` - System timer clock.
-    /// * `app` - The name of the application.
     /// * `mac` - The MAC address of the network.
     /// * `broker` - The IP address of the MQTT broker to use.
     /// * `id` - The MQTT client ID base to use.
@@ -93,7 +92,6 @@ where
         stack: NetworkStack,
         phy: EthernetPhy,
         clock: SystemTimer,
-        app: &str,
         id: &str,
         broker: &str,
         settings: S,
@@ -104,7 +102,7 @@ where
 
         let processor = NetworkProcessor::new(stack_manager.acquire_stack(), phy);
 
-        let prefix = get_device_prefix(app, id);
+        let prefix = get_device_prefix(metadata.app, id);
 
         let store = cortex_m::singleton!(: MqttStorage = MqttStorage::default()).unwrap();
 
@@ -215,7 +213,7 @@ pub fn get_device_prefix(app: &str, id: &str) -> String<128> {
 ///
 /// The alarm is non-latching. If alarm was "true" for a while and the temperatures come within
 /// limits again, alarm will be "false" again.
-#[derive(Clone, Debug, Tree, Default)]
+#[derive(Clone, Debug, Tree)]
 pub struct Alarm {
     /// Set the alarm to armed (true) or disarmed (false).
     /// If the alarm is armed, the device will publish it's alarm state onto the [target].
@@ -254,4 +252,15 @@ pub struct Alarm {
     /// [f32, f32]
     #[tree(depth(4))]
     pub temperature_limits: [[Option<[f32; 2]>; 4]; 4],
+}
+
+impl Default for Alarm {
+    fn default() -> Self {
+        Self {
+            armed: false,
+            target: Default::default(),
+            period: 1.0,
+            temperature_limits: [[Some([f32::NEG_INFINITY, f32::INFINITY]); 4]; 4],
+        }
+    }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -205,18 +205,18 @@ pub fn get_device_prefix(app: &str, id: &str) -> String<128> {
 }
 
 /// Miniconf settings for the MQTT alarm.
-/// The alarm simply publishes "false" onto its [target] as long as all the channels are
-/// within their [temperature_limits] (aka logical OR of all channels).
+/// The alarm simply publishes "false" onto its `target` as long as all the channels are
+/// within their `temperature_limits`` (aka logical OR of all channels).
 /// Otherwise it publishes "true" (aka true, there is an alarm).
 ///
-/// The publishing interval is given by [period_ms].
+/// The publishing interval is given by `period_ms`.
 ///
 /// The alarm is non-latching. If alarm was "true" for a while and the temperatures come within
 /// limits again, alarm will be "false" again.
 #[derive(Clone, Debug, Tree)]
 pub struct Alarm {
     /// Set the alarm to armed (true) or disarmed (false).
-    /// If the alarm is armed, the device will publish it's alarm state onto the [target].
+    /// If the alarm is armed, the device will publish it's alarm state onto the `target`.
     ///
     /// # Value
     /// True to arm, false to disarm.
@@ -245,12 +245,12 @@ pub struct Alarm {
     ///
     /// # Path
     /// `temperature_limits/<adc>/<channel>`
-    /// * <adc> specifies which adc to configure. <adc> := [0, 1, 2, 3]
-    /// * <channel> specifies which channel of an ADC to configure. Only the enabled channels for the specific ADC are available.
+    /// * `<adc> := [0, 1, 2, 3]` specifies which adc to configure.
+    /// * `<channel>` specifies which channel of an ADC to configure. Only the enabled channels for the specific ADC are available.
     ///
     /// # Value
-    /// [f32, f32]
-    #[tree(depth(4))]
+    /// `[f32, f32]` or `None`
+    #[tree(depth(2))]
     pub temperature_limits: [[Option<[f32; 2]>; 4]; 4],
 }
 
@@ -260,7 +260,7 @@ impl Default for Alarm {
             armed: false,
             target: Default::default(),
             period: 1.0,
-            temperature_limits: [[Some([f32::NEG_INFINITY, f32::INFINITY]); 4]; 4],
+            temperature_limits: Default::default(),
         }
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,10 +1,10 @@
-/// Stabilizer network management module
-///
-/// # Design
-/// The stabilizer network architecture supports numerous layers to permit transmission of
-/// telemetry (via MQTT), configuration of run-time settings (via MQTT + Miniconf), and live data
-/// streaming over raw UDP/TCP sockets. This module encompasses the main processing routines
-/// related to Stabilizer networking operations.
+//! Stabilizer network management module
+//!
+//! # Design
+//! The stabilizer network architecture supports numerous layers to permit transmission of
+//! telemetry (via MQTT), configuration of run-time settings (via MQTT + Miniconf), and live data
+//! streaming over raw UDP/TCP sockets. This module encompasses the main processing routines
+//! related to Stabilizer networking operations.
 pub use heapless;
 pub use miniconf;
 pub use serde;
@@ -252,6 +252,6 @@ pub struct Alarm {
     ///
     /// # Value
     /// [f32, f32]
-    #[tree(depth(2))]
+    #[tree(depth(4))]
     pub temperature_limits: [[Option<[f32; 2]>; 4]; 4],
 }

--- a/src/net/network_processor.rs
+++ b/src/net/network_processor.rs
@@ -1,8 +1,8 @@
-/// Task to process network hardware.
-///
-/// # Design
-/// The network processir is a small taks to regularly process incoming data over ethernet, handle
-/// the ethernet PHY state, and reset the network as appropriate.
+//! Task to process network hardware.
+//!
+//! # Design
+//! The network processir is a small taks to regularly process incoming data over ethernet, handle
+//! the ethernet PHY state, and reset the network as appropriate.
 use super::{NetworkReference, UpdateState};
 use crate::hardware::EthernetPhy;
 

--- a/src/net/network_processor.rs
+++ b/src/net/network_processor.rs
@@ -1,8 +1,8 @@
-///! Task to process network hardware.
-///!
-///! # Design
-///! The network processir is a small taks to regularly process incoming data over ethernet, handle
-///! the ethernet PHY state, and reset the network as appropriate.
+/// Task to process network hardware.
+///
+/// # Design
+/// The network processir is a small taks to regularly process incoming data over ethernet, handle
+/// the ethernet PHY state, and reset the network as appropriate.
 use super::{NetworkReference, UpdateState};
 use crate::hardware::EthernetPhy;
 

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -85,7 +85,7 @@ impl<T: Serialize> TelemetryClient<T> {
     }
 
     /// A secondary functionality tugged onto the telemetry client that publishes onto another
-    /// [alarm_topic].
+    /// `alarm_topic`.
     pub fn publish_alarm(&mut self, alarm_topic: &String<128>, alarm: &bool) {
         self.mqtt
             .client()

--- a/src/net/telemetry.rs
+++ b/src/net/telemetry.rs
@@ -1,15 +1,15 @@
-/// Thermostat Telemetry Capabilities
-///
-/// # Design
-/// Telemetry is reported regularly using an MQTT client. All telemetry is reported in SI units
-/// using standard JSON format.
-///
-/// In order to report ADC/DAC codes generated during the DSP routines, a telemetry buffer is
-/// employed to track the latest codes. Converting these codes to SI units would result in
-/// repetitive and unnecessary calculations within the DSP routine, slowing it down and limiting
-/// sampling frequency. Instead, the raw codes are stored and the telemetry is generated as
-/// required immediately before transmission. This ensures that any slower computation required
-/// for unit conversion can be off-loaded to lower priority tasks.
+//! Thermostat Telemetry Capabilities
+//!
+//! # Design
+//! Telemetry is reported regularly using an MQTT client. All telemetry is reported in SI units
+//! using standard JSON format.
+//!
+//! In order to report ADC/DAC codes generated during the DSP routines, a telemetry buffer is
+//! employed to track the latest codes. Converting these codes to SI units would result in
+//! repetitive and unnecessary calculations within the DSP routine, slowing it down and limiting
+//! sampling frequency. Instead, the raw codes are stored and the telemetry is generated as
+//! required immediately before transmission. This ensures that any slower computation required
+//! for unit conversion can be off-loaded to lower priority tasks.
 use heapless::String;
 use serde::Serialize;
 
@@ -55,8 +55,8 @@ impl<T: Serialize> TelemetryClient<T> {
         Self {
             mqtt,
             prefix: String::from(prefix),
-            metadata,
             meta_published: false,
+            metadata,
             _telemetry: core::marker::PhantomData,
         }
     }

--- a/src/output_channel.rs
+++ b/src/output_channel.rs
@@ -31,7 +31,7 @@ pub struct OutputChannel {
     /// The y limits will be clamped to the maximum output current of +-3 A.
     ///
     /// # Value
-    /// See [iir::IIR#tree]
+    /// See [iir::Biquad]
     pub iir: iir::Biquad<f64>,
 
     /// Thermostat input channel weights. Each input temperature of an enabled channel
@@ -40,8 +40,8 @@ pub struct OutputChannel {
     ///
     /// # Path
     /// `weights/<adc>/<channel>`
-    /// * <adc> specifies which adc to configure. <adc> := [0, 1, 2, 3]
-    /// * <channel> specifies which channel of an ADC to configure. Only the enabled channels for the specific ADC are available.
+    /// * `<adc> := [0, 1, 2, 3]` specifies which adc to configure.
+    /// * `<channel>` specifies which channel of an ADC to configure. Only the enabled channels for the specific ADC are available.
     ///
     /// # Value
     /// f32

--- a/src/output_channel.rs
+++ b/src/output_channel.rs
@@ -32,7 +32,7 @@ pub struct OutputChannel {
     ///
     /// # Value
     /// See [iir::IIR#tree]
-    pub iir: iir::IIR<f64>,
+    pub iir: iir::Biquad<f64>,
 
     /// Thermostat input channel weights. Each input temperature of an enabled channel
     /// is multiplied by its weight and the accumulated output is fed into the IIR.
@@ -55,27 +55,18 @@ impl Default for OutputChannel {
             shutdown: true,
             hold: false,
             voltage_limit: 0.0,
-            iir: iir::IIR::default(),
+            iir: iir::Biquad::default(),
             weights: [[None; 4]; 4],
         }
     }
 }
-
-// Global "hold" IIR to apply to a channel iir state [x0,x1,x2,y0,y1] when the output should hold.
-const IIR_HOLD: iir::IIR<f64> = iir::IIR {
-    ba: [0., 0., 0., 1., 0.],
-    y_offset: 0.,
-    y_min: f64::MIN,
-    y_max: f64::MAX,
-};
 
 impl OutputChannel {
     /// compute weighted iir input, iir state and return the new output
     pub fn update(
         &mut self,
         channel_temperatures: &[[f64; 4]; 4],
-        iir_state: &mut iir::Vec5<f64>,
-        hold: bool,
+        iir_state: &mut [f64; 4],
     ) -> f32 {
         let weighted_temperature = channel_temperatures
             .iter()
@@ -85,9 +76,9 @@ impl OutputChannel {
             .map(|(t, w)| t * w.unwrap_or(0.) as f64)
             .sum();
         if self.shutdown || self.hold {
-            IIR_HOLD.update(iir_state, weighted_temperature, hold) as f32
+            iir::Biquad::HOLD.update(iir_state, weighted_temperature) as f32
         } else {
-            self.iir.update(iir_state, weighted_temperature, hold) as f32
+            self.iir.update(iir_state, weighted_temperature) as f32
         }
     }
 
@@ -96,14 +87,16 @@ impl OutputChannel {
     /// - Normalization of the weights
     /// Returns the current limits.
     pub fn finalize_settings(&mut self) -> [f32; 2] {
-        self.iir.y_max = self
-            .iir
-            .y_max
-            .clamp(-Pwm::MAX_CURRENT_LIMIT, Pwm::MAX_CURRENT_LIMIT);
-        self.iir.y_min = self
-            .iir
-            .y_min
-            .clamp(-Pwm::MAX_CURRENT_LIMIT, Pwm::MAX_CURRENT_LIMIT);
+        self.iir.set_max(
+            self.iir
+                .max()
+                .clamp(-Pwm::MAX_CURRENT_LIMIT, Pwm::MAX_CURRENT_LIMIT),
+        );
+        self.iir.set_min(
+            self.iir
+                .min()
+                .clamp(-Pwm::MAX_CURRENT_LIMIT, Pwm::MAX_CURRENT_LIMIT),
+        );
         self.voltage_limit = self.voltage_limit.clamp(0.0, Pwm::MAX_VOLTAGE_LIMIT);
         let divisor: f32 = self
             .weights
@@ -121,8 +114,8 @@ impl OutputChannel {
         [
             // [Pwm::MAX_CURRENT_LIMIT] + 5% is still below 100% duty cycle for the PWM limits and therefore OK.
             // Might not be OK for a different shunt resistor or different PWM setup.
-            (self.iir.y_max + 0.05 * Pwm::MAX_CURRENT_LIMIT).max(0.) as f32,
-            (self.iir.y_min - 0.05 * Pwm::MAX_CURRENT_LIMIT).min(0.) as f32,
+            (self.iir.max() + 0.05 * Pwm::MAX_CURRENT_LIMIT).max(0.) as f32,
+            (self.iir.min() - 0.05 * Pwm::MAX_CURRENT_LIMIT).min(0.) as f32,
         ]
     }
 }

--- a/src/output_channel.rs
+++ b/src/output_channel.rs
@@ -3,10 +3,10 @@
 
 use crate::hardware::pwm::Pwm;
 use idsp::iir;
-use miniconf::Miniconf;
+use miniconf::Tree;
 use num_traits::Signed;
 
-#[derive(Copy, Clone, Debug, Miniconf)]
+#[derive(Copy, Clone, Debug, Tree)]
 pub struct OutputChannel {
     /// En-/Disables the TEC driver. This implies "hold".
     ///
@@ -31,7 +31,7 @@ pub struct OutputChannel {
     /// The y limits will be clamped to the maximum output current of +-3 A.
     ///
     /// # Value
-    /// See [iir::IIR#miniconf]
+    /// See [iir::IIR#tree]
     pub iir: iir::IIR<f64>,
 
     /// Thermostat input channel weights. Each input temperature of an enabled channel
@@ -45,8 +45,8 @@ pub struct OutputChannel {
     ///
     /// # Value
     /// f32
-    #[miniconf(defer)]
-    pub weights: miniconf::Array<miniconf::Array<Option<f32>, 4>, 4>,
+    #[tree(depth(3))]
+    pub weights: [[Option<f32>; 4]; 4],
 }
 
 impl Default for OutputChannel {
@@ -56,7 +56,7 @@ impl Default for OutputChannel {
             hold: false,
             voltage_limit: 0.0,
             iir: iir::IIR::default(),
-            weights: miniconf::Array::default(),
+            weights: [[None; 4]; 4],
         }
     }
 }

--- a/src/output_channel.rs
+++ b/src/output_channel.rs
@@ -55,7 +55,7 @@ impl Default for OutputChannel {
             shutdown: true,
             hold: false,
             voltage_limit: 0.0,
-            iir: iir::Biquad::default(),
+            iir: Default::default(),
             weights: [[0.0; 4]; 4],
         }
     }

--- a/src/output_channel.rs
+++ b/src/output_channel.rs
@@ -45,7 +45,7 @@ pub struct OutputChannel {
     ///
     /// # Value
     /// f32
-    #[tree(depth(3))]
+    #[tree(depth(2))]
     pub weights: [[Option<f32>; 4]; 4],
 }
 


### PR DESCRIPTION
This PR updates miniconf, minimq, and smoltcp to use the latest versions of each. This specifically impacts thermostat in the following ways:
* DNS is used for broker `mqtt` now instead of static IP address
* A STATIC_IP can be assigned to thermostat at build time using the `STATIC_IP` environment variable

TODO:
- [x] Report thermostat metadata on the alive topic.

Note: I do not have a thermostat to test these updates with. These changes are mostly taken verbatim from `stabilizer` source code.